### PR TITLE
Add model for combined sleep data and function for workout detection

### DIFF
--- a/healy_package/lib/healy_watch_sdk.dart
+++ b/healy_package/lib/healy_watch_sdk.dart
@@ -301,4 +301,13 @@ abstract class HealyWatchSDK {
   Future<String?> checkIfFirmwareUpdateAvailable(String currentVersion);
 
   Stream<double> downloadLatestFirmwareUpdate(String downloadUrl);
+
+  /// Returns all collected and combined sleep data
+  Stream<List<HealyCombinedSleepData>> getAllCombinedSleepData();
+
+  /// Returns if an workout is currently running
+  Future<bool> isWorkoutRunning();
+
+  /// return an stream of current workout data as [HealyExerciseData]
+  Stream<HealyBaseExerciseData> currentWorkoutData();
 }

--- a/healy_package/lib/model/models.dart
+++ b/healy_package/lib/model/models.dart
@@ -767,7 +767,9 @@ enum HealyFunction {
   musicControlPre,
   musicControlNext,
   musicControlPlay,
-  musicControlPause
+  musicControlPause,
+  workoutStart,
+  workoutEnd,
 }
 
 class HealySleepModeData {
@@ -790,4 +792,21 @@ class HealyResUpdateData {
   int updateIndex;
 
   HealyResUpdateData({required this.needUpdate, required this.updateIndex});
+}
+
+/// In this model the sleep data is cobined. This means
+/// that this model represent an whole sleep, with all included
+/// data of sleep quality and heart rate.
+class HealyCombinedSleepData {
+  final DateTime startDateTime;
+  final DateTime endDateTime;
+  final List<int> sleepQuality;
+  final List<int> heartRate;
+
+  HealyCombinedSleepData({
+    required this.startDateTime,
+    required this.endDateTime,
+    required this.sleepQuality,
+    required this.heartRate,
+  });
 }


### PR DESCRIPTION
In this PR you see how we would like to have combined sleep data. The combined sleep data is the whole sleep of a user with start and end time and also all quality and heart rate data.

To detect if an workout is starting via Healy Watch device, it would be perfect, if we get notification via function and if we can check if currently an workout is running.